### PR TITLE
Feature/step6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 ## Mac OS ##
 .DS_Store
+
+## Test ##
+test.html

--- a/myPromise.js
+++ b/myPromise.js
@@ -21,7 +21,20 @@ let Fromis9 = function Fromis9(callback) {
   let _reject = function (value) {
     queueMicrotask(() => {
       let result = _error && _error(value);
-      _nextReject && _nextReject(result);
+
+      if (result instanceof Fromis9) {
+        result.then(value => {
+          _nextReject && _nextReject(value);
+        });
+      } else {
+        if (!_error) {
+          if (_nextReject) {
+            _nextReject && _nextReject(value);
+          } else {
+            console.error(value);
+          }
+        }
+      }
     })
   };
 
@@ -38,7 +51,10 @@ let Fromis9 = function Fromis9(callback) {
   this.catch = function(error) {
     _error = error;
 
-    return this;
+    return new Fromis9((resolve, reject) => {
+      _nextResolve = resolve;
+      _nextReject = reject;
+    });
   }
   
   try {

--- a/myPromise.js
+++ b/myPromise.js
@@ -15,7 +15,7 @@ let Fromis9 = function Fromis9(callback) {
       } else {
         _nextResolve && _nextResolve(result);
       }
-    })
+    });
   }
 
   let _reject = function (value) {
@@ -35,7 +35,7 @@ let Fromis9 = function Fromis9(callback) {
           }
         }
       }
-    })
+    });
   };
 
   this.then = function(success, error) {
@@ -66,101 +66,59 @@ let Fromis9 = function Fromis9(callback) {
 
 /* -------------------------------------------- */
 
-let getBuyCount = function () {
-  console.log('Promise:', 2);
-  
-  let promise = new Promise((resolve, reject) => {
-    console.log('Promise:', 3);
-    setTimeout(() => {
-      resolve(4);
-    }, 1000);
-    console.log('Promise:', 5);
-  })
-  console.log('Promise:', 6);
-  return promise;
-};
-
-let getPoint = function (buyCount) {
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      resolve(buyCount * 3000);
-    }, 1000);
-  });
-};
-
-/* -------------------------------------------- */
-
-let getBuyCountFromis9 = function () {
-  console.log("Fromis9:", 2);
-
-  let fromis9 = new Fromis9((resolve, reject) => {
-    console.log("Fromis9:", 3);
-    setTimeout(() => {
-      resolve(4);
-    }, 1000);
-    console.log("Fromis9:", 5);
-  });
-  console.log("Fromis9:", 6);
-  return fromis9;
-};
-
-let getPointFromis9 = function (buyCount) {
-  return new Fromis9((resolve, reject) => {
-    setTimeout(() => {
-      resolve(buyCount * 3000);
-    }, 1000);
-  });
-};
-
-/* -------------------------------------------- */
-
 // 예제 출력
-// console.log("Promise:", 1);
-// getBuyCount()
-//   .then(getPoint)
-//   .then((value) => {
-//     console.log("Promise:", "then2", value);
-//   }).catch(error => {
-//     console.error("Promise:", "error", error);
-//   });
-// console.log("Promise:", 7);
-
 let promise = function() {
   return new Promise((resolve, reject) => {
-    reject(undefined);
+    // throw new Error('throw Error');
+    // reject(new Error('reject Error'));
+    resolve(3);
   });
 };
 
 promise().then(value => {
   console.log('Promise then', value);
+  throw new Error('then error');
+  // return new Promise((resolve, reject) => {
+    // new Error('promise then new Error')
+    // reject(new Error('promise then new Error'));
+  // });
 }).catch(error => {
   console.log('Promise catch', error);
+  // throw new Error('catch error');
+  // return new Promise((resolve, reject) => {
+  //   reject('catchResolve');
+  // });
 }).catch(error => {
   console.log('Promise catch2', error);
+}).then(value => {
+  console.log('Promise then2', value);
 });
 
 
 // 직접 만든 Fromis9 출력
-// console.log("Fromis9:", 1);
-// getBuyCountFromis9()
-//   .then(getPointFromis9)
-//   .then((value) => {
-//     console.log("Fromis9:", "then2", value);
-//   }).catch(error => {
-//     console.error("Fromis9", "error", error);
-//   });
-// console.log("Fromis9:", 7);
-
 let fromis9 = function() {
   return new Fromis9((resolve, reject) => {
-    reject(undefined);
+    // throw new Error('throw Error');
+    // reject(new Error('reject Error'));
+    resolve(3);
   });
 };
 
 fromis9().then(value => {
   console.log('Fromis9 then', value);
+  throw new Error('then error');
+  // return new Fromis9((resolve, reject) => {
+    // new Error('fromis9 then new Error')
+    // reject(new Error('fromis9 then new Error'));
+  // });
 }).catch(error => {
   console.log('Fromis9 catch', error);
+  // throw new Error('catch error');
+  // return new Fromis9((resolve, reject) => {
+  //   reject('catchResolve');
+  // });
 }).catch(error => {
   console.log('Fromis9 catch2', error);
+}).then(value => {
+  console.log('Fromis9 then2', value);
 });

--- a/myPromise.js
+++ b/myPromise.js
@@ -99,24 +99,52 @@ let getPointFromis9 = function (buyCount) {
 /* -------------------------------------------- */
 
 // 예제 출력
-console.log("Promise:", 1);
-getBuyCount()
-  .then(getPoint)
-  .then((value) => {
-    console.log("Promise:", "then2", value);
-  }).catch(error => {
-    console.error("Promise:", "error", error);
+// console.log("Promise:", 1);
+// getBuyCount()
+//   .then(getPoint)
+//   .then((value) => {
+//     console.log("Promise:", "then2", value);
+//   }).catch(error => {
+//     console.error("Promise:", "error", error);
+//   });
+// console.log("Promise:", 7);
+
+let promise = function() {
+  return new Promise((resolve, reject) => {
+    reject(undefined);
   });
-console.log("Promise:", 7);
+};
+
+promise().then(value => {
+  console.log('Promise then', value);
+}).catch(error => {
+  console.log('Promise catch', error);
+}).catch(error => {
+  console.log('Promise catch2', error);
+});
 
 
 // 직접 만든 Fromis9 출력
-console.log("Fromis9:", 1);
-getBuyCountFromis9()
-  .then(getPointFromis9)
-  .then((value) => {
-    console.log("Fromis9:", "then2", value);
-  }).catch(error => {
-    console.error("Fromis9", "error", error);
+// console.log("Fromis9:", 1);
+// getBuyCountFromis9()
+//   .then(getPointFromis9)
+//   .then((value) => {
+//     console.log("Fromis9:", "then2", value);
+//   }).catch(error => {
+//     console.error("Fromis9", "error", error);
+//   });
+// console.log("Fromis9:", 7);
+
+let fromis9 = function() {
+  return new Fromis9((resolve, reject) => {
+    reject(undefined);
   });
-console.log("Fromis9:", 7);
+};
+
+fromis9().then(value => {
+  console.log('Fromis9 then', value);
+}).catch(error => {
+  console.log('Fromis9 catch', error);
+}).catch(error => {
+  console.log('Fromis9 catch2', error);
+});

--- a/myPromise.js
+++ b/myPromise.js
@@ -29,7 +29,7 @@ let Fromis9 = function Fromis9(callback) {
       } else {
         if (!_error) {
           if (_nextReject) {
-            _nextReject && _nextReject(value);
+            _nextReject(value);
           } else {
             console.error(value);
           }

--- a/myPromise.js
+++ b/myPromise.js
@@ -6,34 +6,47 @@ let Fromis9 = function Fromis9(callback) {
 
   let _resolve = function (value) {
     queueMicrotask(() => {
-      let result = _success && _success(value);
-
-      if (result instanceof Fromis9) {
-        result.then(value => {
-          _nextResolve && _nextResolve(value);
-        });
-      } else {
-        _nextResolve && _nextResolve(result);
+      try {
+        let result = _success && _success(value);
+        
+        if (result instanceof Fromis9) {
+          result.then(
+            value => { _nextResolve && _nextResolve(value); },
+            error => { _nextReject && _nextReject(error); }
+          );
+        } else {
+          result = _success ? result : value;
+          _nextResolve && _nextResolve(result);
+        }
+      } catch (e) {
+        _nextReject && _nextReject(e);
       }
     });
   }
-
+  
   let _reject = function (value) {
     queueMicrotask(() => {
-      let result = _error && _error(value);
-
-      if (result instanceof Fromis9) {
-        result.then(value => {
-          _nextReject && _nextReject(value);
-        });
-      } else {
-        if (!_error) {
-          if (_nextReject) {
-            _nextReject(value);
+      try {
+        let result = _error && _error(value);
+  
+        if (result instanceof Fromis9) {
+          result.then(
+            value => { _nextResolve && _nextResolve(value); },
+            error => { _nextReject && _nextReject(error); }
+          );
+        } else {
+          if (!_error) {
+            if (_nextReject) {
+              _nextReject(value);
+            } else {
+              console.error('Uncaught (in Fromis9)', value);
+            }
           } else {
-            console.error(value);
+            _nextResolve(result);
           }
         }
+      } catch (e) {
+        _nextReject && _nextReject(e);
       }
     });
   };
@@ -84,12 +97,14 @@ promise().then(value => {
   // });
 }).catch(error => {
   console.log('Promise catch', error);
-  // throw new Error('catch error');
+  throw new Error('catch error');
+  return 'catch';
   // return new Promise((resolve, reject) => {
   //   reject('catchResolve');
   // });
 }).catch(error => {
   console.log('Promise catch2', error);
+  return 'catch2';
 }).then(value => {
   console.log('Promise then2', value);
 });
@@ -113,12 +128,14 @@ fromis9().then(value => {
   // });
 }).catch(error => {
   console.log('Fromis9 catch', error);
-  // throw new Error('catch error');
+  throw new Error('catch error');
+  return 'catch';
   // return new Fromis9((resolve, reject) => {
   //   reject('catchResolve');
   // });
 }).catch(error => {
   console.log('Fromis9 catch2', error);
+  return 'catch2'
 }).then(value => {
   console.log('Fromis9 then2', value);
 });


### PR DESCRIPTION
- 예외 처리 추가
  - 체이닝을 위해 catch 내에 다음 Promise를 리턴하도록 수정
  - _error callback을 할당 했다면, 다음 체이닝에선 수행하지 않도록 한다. (then 내에서 할당한 뒤의 flow를 생각해야 함)
  - 체이닝 상 두번째 catch에선 error가 이미 할당되어 있으므로 수행하지 않는다.
  - `_resolve`, `_reject` 내부에서 try-catch를 추가하여 then, catch 메서드 내부에서 예외를 터트리는 케이스에도 대응